### PR TITLE
Update Docker CI

### DIFF
--- a/.github/workflows/3-test-docker.yml
+++ b/.github/workflows/3-test-docker.yml
@@ -42,9 +42,11 @@ jobs:
           pip install --no-compile --editable '.[developer,host]'
           armory configure --use-defaults
 
+
+      # TODO: This should really be handled by Dockerfile/Compose.yml
       - name: 🚧 Build the Container
         run: |
-          python docker/build.py pytorch
+          python docker/build.py --framework pytorch
 
       # TODO: Create/mount a volume with the tests can config files.
       - name: 🤞 Run Image tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ developer =[
   "podman",
   # -------- configuration ---------
   "hydra-core",
+  "omegaconf",
 ]
 
 ######################## HOST ###########################


### PR DESCRIPTION
Building the containers should really be delegated to a Dockerfile/Compose script. As it stands, there is no reason it cannot. The `.git` directory would need to be copied into the container, the image built, and artifacts removed; as opposed to just the wheel/sdist. For development purposes, a `VOLUME` should be created- e.g. `/app/bin/armory/` to for mounting of local checkouts.